### PR TITLE
Add coercion support to fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo apt-get install mongodb-org-server
 install:
   - "cpanm -n Test::Pod Test::Pod::Coverage IO::Socket::SSL"
+  - "cpanm -n ODC/Mango-1.16.tar.gz"
   - "cpanm -n --installdeps ."
 notifications:
   email: false

--- a/lib/Mandel/Model.pm
+++ b/lib/Mandel/Model.pm
@@ -153,8 +153,11 @@ sub _field_type {
 
   use Types::Standard qw( Num );
 
+  if ($type->has_coercion) {
+    $code .= '$_ = '.$type->coercion->inline_coercion('$_').";\n";
+  }
   if ($type->can_be_inlined) {
-    $code .= $type->inline_assert('$_');
+    $code .= $type->inline_assert('$_')."\n";
   }
   if ($type->is_a_type_of(Num)) {
     $code .= "\$_ += 0;\n";

--- a/lib/Mandel/Model.pm
+++ b/lib/Mandel/Model.pm
@@ -153,7 +153,7 @@ sub _field_type {
 
   use Types::Standard qw( Num );
 
-  if ($type->has_coercion) {
+  if ($type->has_coercion and $type->coercion->can_be_inlined) {
     $code .= '$_ = '.$type->coercion->inline_coercion('$_').";\n";
   }
   if ($type->can_be_inlined) {

--- a/t/field-coercion.t
+++ b/t/field-coercion.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+package main;
+
+{
+  package WithCoerce;
+  use Mandel::Document;
+  use Types::Standard qw( ArrayRef Str Split );
+  field names => (
+    isa    => (ArrayRef[Str])->plus_coercions(Split[qr/\s/]),
+  );
+}
+
+my $doc = WithCoerce->new;
+
+is_deeply $doc->names('a b c')->names, [qw(a b c)], "Coercion ok!";
+
+done_testing;


### PR DESCRIPTION
The code is based on [Type::Coercion Inlining Methods](https://metacpan.org/pod/Type::Coercion#Inlining-methods). Coercion feature for fields added with a simple test. 

See more `inlined` details in [Type::Tiny `inlined` attribute](https://metacpan.org/pod/Type::Tiny#inlined) 