### PR TITLE
Fix coercion warning

### DIFF
--- a/lib/Mandel/Model.pm
+++ b/lib/Mandel/Model.pm
@@ -126,7 +126,7 @@ sub _add_field {
     # We compile custom attribute code for speed
     no strict 'refs';
     # To fix warnings in coercion
-    no warnings;
+    no warnings qw(syntax once);
     warn "-- Attribute $name in $class\n$code\n\n" if $ENV{MOJO_BASE_DEBUG};
     Carp::croak "Mandel::Document error: $@ ($code)" unless eval "$code;1";
 

--- a/lib/Mandel/Model.pm
+++ b/lib/Mandel/Model.pm
@@ -125,6 +125,8 @@ sub _add_field {
 
     # We compile custom attribute code for speed
     no strict 'refs';
+    # To fix warnings in coercion
+    no warnings;
     warn "-- Attribute $name in $class\n$code\n\n" if $ENV{MOJO_BASE_DEBUG};
     Carp::croak "Mandel::Document error: $@ ($code)" unless eval "$code;1";
 

--- a/t/types.t
+++ b/t/types.t
@@ -6,6 +6,7 @@ field any => (isa => Any);
 field int => (isa => Int);
 field num => (isa => Num);
 field str => (isa => Str);
+field dict => (isa => Dict[key => Str]);
 field 'nonetype';
 
 package main;
@@ -25,16 +26,18 @@ like $@, qr{"Num"}, 'foobar is not Num';
 
 is $doc->str('foobar'), $doc, 'foobar is str';
 
+is_deeply $doc->dict({key => 'value'}), $doc, "dict key value";
+
 $doc->num("1.23");
 $doc->int("42");
 like j($doc->data), qr{\:1\.23}, '1.23 is a number';
 like j($doc->data), qr{\:42},    '42 is a number';
 
 subtest 'types by model' => sub {
-  my @expected = ('Any', 'Int', 'Num', 'Str', undef);
+  my @expected = ('Any', 'Int', 'Num', 'Str', 'Dict[key=>Str]', undef);
   my @fields = map { $_->name } $doc->model->fields;
 
-  is_deeply \@fields, ['any', 'int', 'num', 'str', 'nonetype'], 'fields by model';
+  is_deeply \@fields, ['any', 'int', 'num', 'str', 'dict', 'nonetype'], 'fields by model';
 
   for (0 .. @fields - 1) {
     is $doc->model->field($fields[$_])->type_constraint, $expected[$_], "type $fields[$_]";


### PR DESCRIPTION
I used to set field type as 'Dict' - comes from Types::Standard like Str/Int, then perl warninged this:

> Found = in conditional, should be == at ...

This caused by Types::Standard itself, I issued this yesterday in [p5-type-tiny](https://github.com/tobyink/p5-type-tiny) but none reply.

I've add the `Dict` type to `t/types.t` in commit 9c2e84d4 and `no warnings` before `eval`.

Maybe I should use a Moo-way for field coercions.