### PR TITLE
Fix adding in-storage object bug in `has_many` relationship.

### DIFF
--- a/lib/Mandel/Relationship/BelongsTo.pm
+++ b/lib/Mandel/Relationship/BelongsTo.pm
@@ -123,6 +123,7 @@ sub monkey_patch {
         }
 
         $doc->data->{$foreign_field} = bson_dbref $related_model->collection_name, $obj->id;
+        $doc->dirty->{$foreign_field} = 1 if $doc->dirty;
 
         # Blocking
         unless ($cb) {

--- a/lib/Mandel/Relationship/HasMany.pm
+++ b/lib/Mandel/Relationship/HasMany.pm
@@ -168,6 +168,7 @@ sub _monkey_patch_add_method {
       }
 
       $obj->data->{$foreign_field} = bson_dbref $doc->model->collection_name, $doc->id;
+      $obj->dirty->{$foreign_field} = 1 if $obj->dirty;
 
       # Blocking
       unless ($cb) {

--- a/t/has-many-add-obj.t
+++ b/t/has-many-add-obj.t
@@ -1,0 +1,42 @@
+use t::Online;
+use Test::More;
+
+my $connection = t::Online->mandel;
+my $name       = int rand 10000;
+
+$connection->storage->db->command(dropDatabase => 1);
+
+{
+  my $person = $connection->collection('person')->create({});
+  my $cat = $connection->collection('cat')->create({});
+  $person->add_cats($cat);
+  Mojo::IOLoop->start;
+  ok $person->in_storage, 'person in in_storage';
+
+  my $cats = $person->cats;
+  Mojo::IOLoop->start;
+  is int @$cats, 1, 'cats in storage';
+
+  $cats = $person->cats;
+  is int @$cats, 1, 'cats from cache';
+}
+
+{
+  my $person = $connection->collection('person')->create({});
+  my $cat = $connection->collection('cat')->create({})->save;
+  $person->add_cats($cat);
+  Mojo::IOLoop->start;
+  ok $person->in_storage, 'person in in_storage';
+
+  my $cats = $person->cats;
+  Mojo::IOLoop->start;
+  is int @$cats, 1, 'cats in storage';
+
+  $cats = $person->cats;
+  is int @$cats, 1, 'cats from cache';
+}
+
+$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
+
+done_testing;
+

--- a/t/has-many-add-obj.t
+++ b/t/has-many-add-obj.t
@@ -36,6 +36,21 @@ $connection->storage->db->command(dropDatabase => 1);
   is int @$cats, 1, 'cats from cache';
 }
 
+{
+  my $person = $connection->collection('person')->create({});
+  my $cat = $connection->collection('cat')->create({})->save;
+  $cat->person($person);
+  Mojo::IOLoop->start;
+  ok $person->in_storage, 'person in in_storage';
+
+  my $cats = $person->cats;
+  Mojo::IOLoop->start;
+  is int @$cats, 1, 'cats in storage';
+
+  $cats = $person->cats;
+  is int @$cats, 1, 'cats from cache';
+}
+
 $connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
 
 done_testing;

--- a/t/iterator.t
+++ b/t/iterator.t
@@ -34,3 +34,6 @@ $iterator->next(
   }
 );
 Mojo::IOLoop->start;
+
+$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
+

--- a/t/list-of-blocking.t
+++ b/t/list-of-blocking.t
@@ -57,4 +57,6 @@ $connection->storage->db->command(dropDatabase => 1);
   is $kittens->count, 2, 'counted three kittens';
 }
 
+$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
+
 done_testing;

--- a/t/list-of-non-blocking.t
+++ b/t/list-of-non-blocking.t
@@ -64,4 +64,6 @@ $connection->storage->db->command(dropDatabase => 1);
   is $n, 3, 'three callbacks';
 }
 
+$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
+
 done_testing;

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -100,3 +100,6 @@ $connection->storage->db->command(dropDatabase => 1);
   );
   Mojo::IOLoop->start;
 }
+
+$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};
+


### PR DESCRIPTION
A `has_many` relationship should support add_(something) method
for an document object, as described in POD.
```perl
$person = MyModel::Person->new->add_cats($cat_obj, sub {
            my($person, $err, $cat_obj) = @_;
            # ...
          });
```

A not-in-storage object will be saved as expected, but an in-storage
object will not.

The code(provided as a test script):

```perl
use t::Online;
use Test::More;

my $connection = t::Online->mandel;
my $name       = int rand 10000;

$connection->storage->db->command(dropDatabase => 1);

{ # Passed.
  my $person = $connection->collection('person')->create({});
  my $cat = $connection->collection('cat')->create({});
  $person->add_cats($cat);
  Mojo::IOLoop->start;
  ok $person->in_storage, 'person in in_storage';

  my $cats = $person->cats;
  Mojo::IOLoop->start;
  is int @$cats, 1, 'cats in storage';

  $cats = $person->cats;
  is int @$cats, 1, 'cats from cache';
}

{ # Not pass.
  my $person = $connection->collection('person')->create({});
  my $cat = $connection->collection('cat')->create({})->save;  # the difference
  $person->add_cats($cat);
  Mojo::IOLoop->start;
  ok $person->in_storage, 'person in in_storage';

  my $cats = $person->cats;
  Mojo::IOLoop->start;
  is int @$cats, 1, 'cats in storage';

  $cats = $person->cats;
  is int @$cats, 1, 'cats from cache';
}

$connection->storage->db->command(dropDatabase => 1) unless $ENV{KEEP_DATABASE};

done_testing;

```

Seems because the in-storage object will just pass the check in `save`,
and do nothing:
```perl
if (!$self->is_changed and $self->in_storage) {
  ...
}
```

Fixed by setting the data as dirty.
```
       $obj->data->{$foreign_field} = bson_dbref $doc->model->collection_name, $doc->id;
+      $obj->dirty->{$foreign_field} = 1 if $obj->dirty;
```