### PR TITLE
Non document class checking

### DIFF
--- a/lib/Mandel.pm
+++ b/lib/Mandel.pm
@@ -181,6 +181,8 @@ sub all_document_names {
 
   for my $ns (@{$self->namespaces}) {
     for my $name (find_modules $ns) {
+      my $e = load_class $name;
+      next unless $name->isa('Mandel::Document');
       $name =~ s/^${ns}:://;
       $names{Mojo::Util::decamelize($name)} = 1;
     }

--- a/t/lib/MyModel/Other.pm
+++ b/t/lib/MyModel/Other.pm
@@ -1,3 +1,3 @@
-package MyModel::Menu;
+package MyModel::Other;
 
 1;

--- a/t/lib/MyModel/Other.pm
+++ b/t/lib/MyModel/Other.pm
@@ -1,0 +1,3 @@
+package MyModel::Menu;
+
+1;


### PR DESCRIPTION
This is from when I want to use custom collection class for mandel, I just place the custom
collection class where the document class places. Then `document_classes` method
does not trait the collection class as a **collection class** but a **document class**.

For test, I have added a non-document class called `Other.pm` in "t/lib".
Then the error occurs in "t/mandel.t":

```text
$ perl t/mandel.t

ok 1 - got namespaces
not ok 2 - got document names
#   Failed test 'got document names'
#   at t/mandel.t line 10. 
#     Structures begin differing at: 
#          $got->[0] = 'other'
#     $expected->[0] = 'menu'
ok 3 - got class_for Menu
ok 4 - created clone, with fresh storage
ok 5 - but with same model_class
Can't locate object method "initialize" via package "MyModel::Other" at /home/xxxxx/perl5/lib/perl5/Mandel.pm line 284, <DATA> line 2125.
> # Tests were run but no plan was declared and done_testing() was not seen.
> # Looks like your test exited with 255 just after 5.

```

To fix this, using `isa` for document class checking works ok.
