### PR TITLE
Enable type checking in create() method

### DIFF
--- a/lib/Mandel/Collection.pm
+++ b/lib/Mandel/Collection.pm
@@ -33,7 +33,9 @@ sub create {
   my $cb = ref $_[-1] eq 'CODE' ? pop : undef;
   my $self = shift;
 
-  $self->_new_document(shift || undef, 0);
+  my $doc = $self->_new_document(shift || undef, 0);
+  $doc->_validate_fields;
+  return $doc;
 }
 
 sub count {

--- a/lib/Mandel/Collection.pm
+++ b/lib/Mandel/Collection.pm
@@ -33,9 +33,7 @@ sub create {
   my $cb = ref $_[-1] eq 'CODE' ? pop : undef;
   my $self = shift;
 
-  my $doc = $self->_new_document(shift || undef, 0);
-  $doc->_validate_fields;
-  return $doc;
+  $self->_new_document(shift || undef, 0)->validate_fields;
 }
 
 sub count {

--- a/lib/Mandel/Document.pm
+++ b/lib/Mandel/Document.pm
@@ -240,6 +240,15 @@ sub import {
 
 sub TO_JSON { shift->data }
 
+sub _validate_fields {
+  my $self = shift;
+  if (ref $self->{data} eq 'HASH') {
+    for (grep { $self->can($_) } keys %{ $self->{data} }) {
+      $self->$_($self->{data}{$_});
+    }
+  }
+}
+
 sub _cache {
   my $self = shift;
   my $cache = $self->{cache} ||= {};

--- a/lib/Mandel/Document.pm
+++ b/lib/Mandel/Document.pm
@@ -240,13 +240,14 @@ sub import {
 
 sub TO_JSON { shift->data }
 
-sub _validate_fields {
+sub validate_fields {
   my $self = shift;
   if (ref $self->{data} eq 'HASH') {
     for (grep { $self->can($_) } keys %{ $self->{data} }) {
       $self->$_($self->{data}{$_});
     }
   }
+  return $self;
 }
 
 sub _cache {
@@ -457,6 +458,16 @@ Alias for L</data>.
 
 This method allow the document to get automatically serialized by
 L<Mojo::JSON>.
+
+=head2 validate_fields
+
+  $self = $self->validate_fields;
+
+This method can be used to validate the content of the fields of a document
+againt the types defined in the model. It can be called after a document has
+been loaded from MongoDB, e.g. via L<Mandel::Collection/single>. It can be
+useful if the data in MongoDB might have been altered by something else after
+it was stored there.
 
 =head1 SEE ALSO
 

--- a/t/types.t
+++ b/t/types.t
@@ -1,5 +1,6 @@
 package   MyDocument;
 use Mandel::Document;
+use Mandel::Collection;
 use Types::Standard ':all';
 
 field any => (isa => Any);
@@ -40,4 +41,11 @@ subtest 'types by model' => sub {
     is $doc->model->field($fields[$_])->type_constraint, $expected[$_], "type $fields[$_]";
   }
 };
+
+my $collection = Mandel::Collection->new;
+my $model = Mandel::Model->new(document_class => 'MyDocument');
+$collection->model($model);
+eval { my $doc2 = $collection->create({ int => "Bruce" }) };
+like $@, qr{"Int"}, 'Bruce is not Int';
+
 done_testing;


### PR DESCRIPTION
As discussed in #30 

At least the type checking for known fields now works as expected.

A couple of remarks:
* Using a field in `create()` that wasn't defined in the model still works as before, otherwise it would break existing tests. The behavior could be changed by omitting  the
    ```perl
    grep { $self->can($_) }
    ```
    It would result in messages like: `Can't locate object method "foo" via package "MyModel::Person"` from the `_validate_fields()` sub.
* I've had to add a check if `$self->{data}` was a hash ref in `_validate_fields()` otherwise a test would break where it is explicitly checked for being `undef` (line 21 in `t/field.t`). Simply doing `%{ $self->{data} }` would turn the undefined value into an empty hash ref.